### PR TITLE
fix(database): disable dropSchema in production config

### DIFF
--- a/src/config/database.config.ts
+++ b/src/config/database.config.ts
@@ -5,7 +5,7 @@ export const databaseConfig: TypeOrmModuleOptions = {
   url: 'postgresql://db_contable_dacax_user:ODNA4qVFOAvBMT4Bb2KKLbDb68SRFLRN@dpg-d29obfndiees73d0u5u0-a.oregon-postgres.render.com/db_contable_dacax',
   autoLoadEntities: true,
   synchronize: true,
-  dropSchema: true,
+  //dropSchema: true,
   ssl: {
     rejectUnauthorized: false,
   },


### PR DESCRIPTION
Prevent accidental database schema drops in production by commenting out the dropSchema option while maintaining other database configurations